### PR TITLE
Invoke "ninja" instead of "ninja clang"

### DIFF
--- a/Windows/build.bat
+++ b/Windows/build.bat
@@ -43,8 +43,8 @@ if ERRORLEVEL 1 (goto cmdfailed)
 @echo.Running the build step
 @echo.======================================================================
 
-@echo ninja clang
-ninja clang
+@echo ninja
+ninja
 if ERRORLEVEL 1 (goto cmdfailed)
 
 :succeeded


### PR DESCRIPTION
For testing I had restricted the build only to clang. Now that the testing is
done we can switch to the full llvm builds.