### PR TITLE
Limit no. of parallel jobs to MSBUILD_CPU_COUNT

### DIFF
--- a/Windows/build.bat
+++ b/Windows/build.bat
@@ -48,8 +48,8 @@ if ERRORLEVEL 1 (goto cmdfailed)
 @echo.======================================================================
 
 if "%TEST_SUITE%"=="CheckedC_LLVM" (
-  @echo ninja
-  ninja
+  @echo ninja -j%MSBUILD_CPU_COUNT%
+  ninja -j%MSBUILD_CPU_COUNT%
 ) else (
   @echo ninja clang
   ninja clang

--- a/Windows/build.bat
+++ b/Windows/build.bat
@@ -48,11 +48,11 @@ if ERRORLEVEL 1 (goto cmdfailed)
 @echo.======================================================================
 
 if "%TEST_SUITE%"=="CheckedC_LLVM" (
-  @echo ninja -j%MSBUILD_CPU_COUNT%
-  ninja -j%MSBUILD_CPU_COUNT%
+  @echo ninja -j%CL_CPU_COUNT%
+  ninja -j%CL_CPU_COUNT%
 ) else (
-  @echo ninja clang
-  ninja clang
+  @echo ninja -j%CL_CPU_COUNT% clang
+  ninja -j%CL_CPU_COUNT% clang
 )
 
 if ERRORLEVEL 1 (goto cmdfailed)

--- a/Windows/config-vars.bat
+++ b/Windows/config-vars.bat
@@ -165,7 +165,6 @@ if not defined SIGN_BRANCH (
 )
 
 if NOT DEFINED MSBUILD_BIN (
- @rem used to be: set "MSBUILD_BIN=%programfiles(x86)%\MSBuild\15.0\Bin\MSBuild.exe"
  set "MSBUILD_BIN=%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
 )
 
@@ -178,8 +177,11 @@ if NOT DEFINED MSBUILD_CPU_COUNT (
 )
 
 if NOT DEFINED CL_CPU_COUNT (
-  rem It would be better to calculate this based on total physical memory availablity.
-  set CL_CPU_COUNT=4
+  if "%BUILDCONFIGURATION%"=="Debug" (
+    set /A CL_CPU_COUNT=%MSBUILD_CPU_COUNT%*3/8
+  ) else (
+    set /A CL_CPU_COUNT=%MSBUILD_CPU_COUNT%
+  )
 )
 
 @echo Configured environment variables:

--- a/Windows/test-lit.bat
+++ b/Windows/test-lit.bat
@@ -29,16 +29,16 @@ if "%TEST_SUITE%"=="CheckedC_LLVM" (
   @echo.======================================================================
   @echo.Running the LLVM/Clang regression tests
   @echo.======================================================================
-  @echo ninja -v check-all
-  ninja -v check-all
+  @echo ninja -v -j%MSBUILD_CPU_COUNT% check-all
+  ninja -v -j%MSBUILD_CPU_COUNT% check-all
   if ERRORLEVEL 1 (goto cmdfailed)
 
 ) else (
   @echo.======================================================================
   @echo.Running the Clang regression tests
   @echo.======================================================================
-  @echo ninja -v check-clang
-  ninja -v check-clang
+  @echo ninja -v -j%MSBUILD_CPU_COUNT% check-clang
+  ninja -v -j%MSBUILD_CPU_COUNT% check-clang
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 

--- a/Windows/test-lit.bat
+++ b/Windows/test-lit.bat
@@ -21,24 +21,24 @@ cd %LLVM_OBJ_DIR%
 @echo.Running the Checked C regression tests
 @echo.======================================================================
 
-@echo ninja -v check-checkedc
-ninja -v check-checkedc
+@echo ninja -v -j%CL_CPU_COUNT% check-checkedc
+ninja -v -j%CL_CPU_COUNT% check-checkedc
 if ERRORLEVEL 1 (goto cmdfailed)
 
 if "%TEST_SUITE%"=="CheckedC_LLVM" (
   @echo.======================================================================
   @echo.Running the LLVM/Clang regression tests
   @echo.======================================================================
-  @echo ninja -v -j%MSBUILD_CPU_COUNT% check-all
-  ninja -v -j%MSBUILD_CPU_COUNT% check-all
+  @echo ninja -v -j%CL_CPU_COUNT% check-all
+  ninja -v -j%CL_CPU_COUNT% check-all
   if ERRORLEVEL 1 (goto cmdfailed)
 
 ) else (
   @echo.======================================================================
   @echo.Running the Clang regression tests
   @echo.======================================================================
-  @echo ninja -v -j%MSBUILD_CPU_COUNT% check-clang
-  ninja -v -j%MSBUILD_CPU_COUNT% check-clang
+  @echo ninja -v -j%CL_CPU_COUNT% check-clang
+  ninja -v -j%CL_CPU_COUNT% check-clang
   if ERRORLEVEL 1 (goto cmdfailed)
 )
 


### PR DESCRIPTION
When there are a lot of parallel build/link jobs on Windows, we may run into "out of heap" errors.