### PR TITLE
Misc fixes to automation scripts

### DIFF
--- a/UNIX/build-package.sh
+++ b/UNIX/build-package.sh
@@ -37,8 +37,8 @@ echo "======================================================================"
 mkdir -p "package"
 rm -rf "package/*"
 
-# Build it
-ninja package
+echo ninja -v -j${BUILD_CPU_COUNT} package
+ninja -v -j${BUILD_CPU_COUNT} package
 if [ "$?" -ne "0" ]; then
   cmdfailed
 fi

--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -55,7 +55,13 @@ fi
 echo "======================================================================"
 echo "Running the build step"
 echo "======================================================================"
-ninja
+if [[ "$TEST_SUITE" == "CheckedC_LLVM" ]]; then
+  echo -j${BUILD_CPU_COUNT} ninja
+  ninja -j${BUILD_CPU_COUNT}
+else
+  echo ninja -j${BUILD_CPU_COUNT} clang
+  ninja -j${BUILD_CPU_COUNT} clang
+fi
 
 set +x
 set +ue

--- a/UNIX/test-lit.sh
+++ b/UNIX/test-lit.sh
@@ -18,23 +18,17 @@ if [ ! -e "`which clang`" ]; then
   exit 1
 fi
 
-cd ${LLVM_OBJ_DIR}
+cd $LLVM_OBJ_DIR
 
-echo "======================================================================"
-echo "Running ninja -v check-checkedc"
-echo "======================================================================"
-ninja -v check-checkedc
+echo ninja -v -j${BUILD_CPU_COUNT} check-checkedc
+ninja -v -j${BUILD_CPU_COUNT} check-checkedc
 
-if [ "${TEST_SUITE}" == "CheckedC_LLVM" ]; then
-  echo "======================================================================"
-  echo "Running ninja -v check-all"
-  echo "======================================================================"
-  ninja -v check-all
+if [ "$TEST_SUITE" == "CheckedC_LLVM" ]; then
+  echo ninja -v -j${BUILD_CPU_COUNT} check-all
+  ninja -v -j${BUILD_CPU_COUNT} check-all
 else
-  echo "======================================================================"
-  echo "Running ninja -v check-clang"
-  echo "======================================================================"
-  ninja -v check-clang
+  echo ninja -v -j${BUILD_CPU_COUNT} check-clang
+  ninja -v -j${BUILD_CPU_COUNT} check-clang
 fi
 
 set +ue

--- a/Windows/build-package.bat
+++ b/Windows/build-package.bat
@@ -1,32 +1,28 @@
 @echo off
 
-rem Build an installation package for clang.
-rem
-rem The MSBuild task in Visual Studio uses a relative path to the
-rem solution file, which does not work for CMake-generated files, 
-rem which should be generated outside the source tree   So create a
-rem a script and just invoke MSBuild directly.
-
 @setlocal
 @call checkedc-automation\Windows\config-vars.bat
 if ERRORLEVEL 1 (goto cmdfailed)
+
+rem Set path to Unix utilities.
+set PATH="C:\GnuWin32\bin";%PATH%
 
 set OLD_DIR=%CD%
 cd %LLVM_OBJ_DIR%
 
 if "%BUILD_PACKAGE%" == "No" (goto succeeded)
 
-echo.Building installation package for clang
-"%MSBUILD_BIN%" PACKAGE.vcxproj /p:Configuration=%BUILDCONFIGURATION% /v:%MSBUILD_VERBOSITY% /maxcpucount:%MSBUILD_CPU_COUNT% /p:CL_MPCount=%CL_CPU_COUNT%
- if ERRORLEVEL 1 (goto cmdfailed)
+@echo.======================================================================
+@echo.Building an installation package for clang
+@echo.======================================================================
 
-rem Put the installer executable in its own subdirectory.  The VSTS build
-rem artifact copy task can only copy directories or specifically named files
-rem (no wild cards), and the installer executable name includes a version
-rem number.
+@echo ninja -v -j%CL_CPU_COUNT% package
+ninja -v -j%CL_CPU_COUNT% package
+if ERRORLEVEL 1 (goto cmdfailed)
 
- move LLVM-*.exe package
-  if ERRORLEVEL 1 (goto cmdfailed)
+rem Put the installer executable in its own subdirectory.
+move LLVM-*.exe package
+if ERRORLEVEL 1 (goto cmdfailed)
 
 :succeeded
   cd %OLD_DIR%

--- a/Windows/build.bat
+++ b/Windows/build.bat
@@ -28,14 +28,20 @@ cd %LLVM_OBJ_DIR%
 @echo "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %TEST_TARGET_ARCH%
 @call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %TEST_TARGET_ARCH%
 
-set EXTRA_FLAGS=
-if "%BUILDCONFIGURATION%"=="Release" (
-  set EXTRA_FLAGS="-DLLVM_USE_CRT_RELEASE=MT"
-  if "%BUILD_PACKAGE%"=="Yes" (
-    set EXTRA_FLAGS="%EXTRA_FLAGS% -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON"
+if "%BUILD_PACKAGE%"=="Yes" (
+  if "%BUILDCONFIGURATION%"=="Release" (
+    set EXTRA_FLAGS=-DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON
+  ) else (
+    set EXTRA_FLAGS=
   )
 ) else (
-  set EXTRA_FLAGS="-DLLVM_USE_CRT_DEBUG=MTd"
+  set EXTRA_FLAGS=
+)
+
+if "%BUILDCONFIGURATION%"=="Release" (
+  set EXTRA_FLAGS=%EXTRA_FLAGS% -DLLVM_USE_CRT_RELEASE=MT
+) else (
+  set EXTRA_FLAGS=%EXTRA_FLAGS% -DLLVM_USE_CRT_DEBUG=MTd
 )
 
 @echo cmake -G Ninja -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=all -DCMAKE_BUILD_TYPE=%BUILDCONFIGURATION% %EXTRA_FLAGS% %BUILD_SOURCESDIRECTORY%\llvm
@@ -47,7 +53,10 @@ if ERRORLEVEL 1 (goto cmdfailed)
 @echo.Running the build step
 @echo.======================================================================
 
-if "%TEST_SUITE%"=="CheckedC_LLVM" (
+if "%BUILD_PACKAGE%"=="Yes" (
+  @echo ninja -j%CL_CPU_COUNT%
+  ninja -j%CL_CPU_COUNT%
+) else if "%TEST_SUITE%"=="CheckedC_LLVM" (
   @echo ninja -j%CL_CPU_COUNT%
   ninja -j%CL_CPU_COUNT%
 ) else (

--- a/Windows/checkout.bat
+++ b/Windows/checkout.bat
@@ -5,7 +5,7 @@
 if ERRORLEVEL 1 (goto cmdfailed)
 
 @echo.======================================================================
-@echo.Checking out checkedc and test-suite sources
+@echo.Checking out checkedc
 @echo.======================================================================
 
 set OLD_DIR=%CD%

--- a/Windows/config-vars.bat
+++ b/Windows/config-vars.bat
@@ -11,8 +11,6 @@ rem running it manually, the variables must be set by the user.
 
 rem Create configuration variables
 
-set MSBUILD_VERBOSITY=n
-
 if NOT DEFINED BUILD_CHECKEDC_CLEAN (
   if DEFINED BUILD_CLEAN (
     set BUILD_CHECKEDC_CLEAN=Yes
@@ -164,10 +162,6 @@ if not defined SIGN_BRANCH (
   set SIGN_BRANCH=master
 )
 
-if NOT DEFINED MSBUILD_BIN (
- set "MSBUILD_BIN=%programfiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\MSBuild.exe"
-)
-
 if NOT DEFINED MSBUILD_CPU_COUNT (
   if DEFINED NUMBER_OF_PROCESSORS (
     set MSBUILD_CPU_COUNT=%NUMBER_OF_PROCESSORS%
@@ -205,7 +199,6 @@ if NOT DEFINED CL_CPU_COUNT (
 @echo.    CHECKEDC BRANCH: %CHECKEDC_BRANCH%
 @echo.    SIGN_BRANCH: %SIGN_BRANCH%
 @echo.
-@echo.  MSBUILD_BIN: %MSBUILD_BIN%
 @echo.  MSBUILD_CPU_COUNT: %MSBUILD_CPU_COUNT%
 @echo.  CL_CPU_COUNT: %CL_CPU_COUNT%
 


### PR DESCRIPTION
- Switched over the building of clang installation package to ninja.
- Removed MSBUILD_BIN and MSBUILD_VERBOSITY variables
- Limited the no. of parallel jobs for Linux builds
- Added options LLVM_USE_CRT_DEBUG=MTd and LLVM_USE_CRT_RELEASE=MT to cmake.