### PR TITLE
Setup benchmarking automation for Checked C

### DIFF
--- a/UNIX/ARM/invoke-lnt.sh
+++ b/UNIX/ARM/invoke-lnt.sh
@@ -18,12 +18,13 @@ if [[ "$BMARK" = "yes" ]]; then
     --cc "$CC" \
     --cxx "$CXX" \
     --cflags "$CFLAGS" \
-    --qemu-user-mode "$RUN" \
+    --run-under "$RUN" \
     --test-suite "$BUILD_SOURCESDIRECTORY/llvm-test-suite" \
     --submit "$LNT_DB_DIR" \
     --only-test "$ONLY_TEST" \
     --exec-multisample "$SAMPLES" \
     --run-order "$USER" \
+    --cmake-define "CMAKE_STRIP:FILEPATH=llvm-strip" \
     ${EXTRA_LNT_ARGS} \
     2>&1 | tee $RESULT_SUMMARY
 

--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -62,8 +62,8 @@ elif [[ "$TEST_SUITE" == "CheckedC_LLVM" ]]; then
   echo ninja -j${BUILD_CPU_COUNT}
   ninja -j${BUILD_CPU_COUNT}
 else
-  echo ninja -j${BUILD_CPU_COUNT} clang
-  ninja -j${BUILD_CPU_COUNT} clang
+  echo ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip
+  ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip
 fi
 
 set +x

--- a/UNIX/config-vars.sh
+++ b/UNIX/config-vars.sh
@@ -154,7 +154,7 @@ else
   export ONLY_TEST
 
   if [[ -z "$SAMPLES" ]]; then
-    SAMPLES=3
+    SAMPLES=1
   fi
   export SAMPLES
 fi

--- a/UNIX/config-vars.sh
+++ b/UNIX/config-vars.sh
@@ -127,7 +127,7 @@ if [[ -z "$BENCHMARK" ]]; then
   export BMARK=no
 
 else
-  LNT_DB_DIR=/usr/local/checkedc/lnt-setup/llvm.lnt.db
+  LNT_DB_DIR=/lnt-install/llvm.lnt.db
   if [ ! -d ${LNT_DB_DIR} ]; then
     echo "No LNT DB found at $LNT_DB_DIR"
     exit 1
@@ -168,7 +168,12 @@ if [ -z "$LNT" ]; then
   export LNT_RESULTS_DIR=""
   export LNT_SCRIPT=""
 else
-  export LNT_RESULTS_DIR="${BUILD_BINARIESDIRECTORY}/LNT-Results-${BUILDCONFIGURATION}-${BUILDOS}"
+  LNT_RESULTS_DIR="${BUILD_BINARIESDIRECTORY}/LNT-Results-${BUILDCONFIGURATION}-${BUILDOS}"
+  if [[ "$BENCHMARK" = "yes" ]]; then
+    LNT_RESULTS_DIR+="-Benchmarking"
+  fi
+  export LNT_RESULTS_DIR
+
   if [ "$RUN_LOCAL" = "no" ]; then
     # We assume that lnt is installed in /lnt-install on test machines.
     export LNT_SCRIPT=/lnt-install/sandbox/bin/lnt

--- a/UNIX/test-lnt-benchmarks.sh
+++ b/UNIX/test-lnt-benchmarks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+TOPDIR=$(dirname "$0")
+
+# Note: You can set the following optional flags here:
+# ONLY_TEST=SingleSource/Benchmarks/Dhrystone : Runs only the specified benchmarks.
+# SAMPLES=1 : Runs each benchmark SAMPLES no. of times. Default SAMPLES=3.
+
+BENCHMARK=yes \
+$TOPDIR/test-lnt.sh

--- a/UNIX/test-lnt-benchmarks.sh
+++ b/UNIX/test-lnt-benchmarks.sh
@@ -4,7 +4,7 @@ TOPDIR=$(dirname "$0")
 
 # Note: You can set the following optional flags here:
 # ONLY_TEST=SingleSource/Benchmarks/Dhrystone : Runs only the specified benchmarks.
-# SAMPLES=1 : Runs each benchmark SAMPLES no. of times. Default SAMPLES=3.
+# SAMPLES=n : Runs each benchmark SAMPLES no. of times. Default SAMPLES=1.
 
 BENCHMARK=yes \
 $TOPDIR/test-lnt.sh


### PR DESCRIPTION
- Invoke benchmarking through a new wrapper script test-lnt-benchmarks.sh.
- Use the local LNT db from /lnt-install/llvm.lnt.db.
- Suffix the current LNT work dir with "-Benchmarking" and use it for the
  benchmarking.
- Use llvm-size and llvm-strip for ARM code size.

Usage:
  BENCHMARK=yes checkedc-automation/UNIX/test-lnt-benchmarks.sh

Prerequisites:
- Linux machine checkc-test02 has been added to the Checked C agent pool.
- The dir /mnt/work on checkc-test02 would be used as work dir for the benchmarking runs.
- LNT installed at /lnt-install on checkc-test02.
- LNT database installed at /lnt-install/llvm.lnt.db on checkc-test02.

We have two Linux machines for ADO runs: checkc-test01 and checkc-test02. We want to use checkc-test01 for the regular LNT runs while we want to use checkc-test02 only for benchmarking.
So we had to fix the agent selection under ADO jobs -> Validations as follows:
- Added "Agent.Name equals checkc-test01" for regular LNT runs.
- Added "Agent.Name equals checkc-test02" for regular benchmarking runs.