### PR TITLE
Get rid of LNT_DB_DIR

### DIFF
--- a/UNIX/ARM/invoke-lnt.sh
+++ b/UNIX/ARM/invoke-lnt.sh
@@ -21,7 +21,6 @@ if [[ "$BMARK" = "yes" ]]; then
     --cflags "$CFLAGS" \
     --run-under "$RUN" \
     --test-suite "$TESTSUITE" \
-    --submit "$LNT_DB_DIR" \
     --only-test "$ONLY_TEST" \
     --exec-multisample "$SAMPLES" \
     --run-order "$USER" \

--- a/UNIX/X86_64/invoke-lnt.sh
+++ b/UNIX/X86_64/invoke-lnt.sh
@@ -17,7 +17,6 @@ if [[ "$BMARK" = "yes" ]]; then
     --cxx "$CXX" \
     --cflags "$CFLAGS" \
     --test-suite "$TESTSUITE" \
-    --submit "$LNT_DB_DIR" \
     --only-test "$ONLY_TEST" \
     --exec-multisample "$SAMPLES" \
     --run-order "$USER" \

--- a/UNIX/config-vars.sh
+++ b/UNIX/config-vars.sh
@@ -127,13 +127,7 @@ if [[ -z "$BENCHMARK" ]]; then
   export BMARK=no
 
 else
-  LNT_DB_DIR=/lnt-install/llvm.lnt.db
-  if [ ! -d ${LNT_DB_DIR} ]; then
-    echo "No LNT DB found at $LNT_DB_DIR"
-    exit 1
-  fi
   export BMARK=yes
-  export LNT_DB_DIR
 
   EXTRA_LNT_ARGS=
   for OPT in $METRICS; do
@@ -194,7 +188,6 @@ if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
   echo " LNT_SCRIPT: $LNT_SCRIPT"
   echo " RUN_LOCAL: $RUN_LOCAL"
   echo " BENCHMARK: $BMARK"
-  echo " LNT_DB_DIR: $LNT_DB_DIR"
   echo
   echo " Directories:"
   echo "  BUILD_SOURCESDIRECTORY: $BUILD_SOURCESDIRECTORY"


### PR DESCRIPTION
We have set up an Azure Table Storage to store LNT benchmark data. So we no
longer need to save data on the local LNT database.