### PR TITLE
Add support to clean src and build dirs

### DIFF
--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# For a description of the config variables set/used here,
-# see automation/Windows/build-and-test.bat.
-
 source ./config-vars.sh
 
 echo "======================================================================"

--- a/UNIX/checkout.sh
+++ b/UNIX/checkout.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# For a description of the config variables set/used here,
-# see automation/Windows/build-and-test.bat.
-
 source ./config-vars.sh
 
 echo "======================================================================"

--- a/UNIX/cleanup.sh
+++ b/UNIX/cleanup.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# For a description of the config variables set/used here,
-# see automation/Windows/build-and-test.bat.
-
 source ./config-vars.sh
 
 echo "======================================================================"

--- a/UNIX/cleanup.sh
+++ b/UNIX/cleanup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# For a description of the config variables set/used here,
+# see automation/Windows/build-and-test.bat.
+
+source ./config-vars.sh
+
+echo "======================================================================"
+echo "Cleaning Checked C src and build dirs"
+echo "======================================================================"
+
+set -ue
+set -o pipefail
+
+if [ "$CLEAN_SRC_BUILD_DIR" == "No" ]; then
+  echo "Clean.Src.Build.Dir is set to No. Nothing to clean."
+
+elif [ "$CLEAN_SRC_BUILD_DIR"=="Yes" ]; then
+  echo "Clean.Src.Build.Dir is set to Yes. Trying to clean dirs."
+
+  if [ -d "$BUILD_SOURCESDIRECTORY" ]; then
+    echo "Cleaning src dir: $BUILD_SOURCESDIRECTORY"
+    rm -rf "$BUILD_SOURCESDIRECTORY"
+  else
+    echo "Src dir $BUILD_SOURCESDIRECTORY not found"
+  fi
+
+  if [ -d "$LLVM_OBJ_DIR" ]; then
+    echo "Cleaning build dir: $LLVM_OBJ_DIR"
+    rm -rf "$LLVM_OBJ_DIR"
+  else
+    echo "Build dir $LLVM_OBJ_DIR not found"
+  fi
+fi
+
+set +ue
+set +o pipefail

--- a/UNIX/config-vars.sh
+++ b/UNIX/config-vars.sh
@@ -18,6 +18,13 @@ CHECKEDC_CONFIG_STATUS="passed"
 
 # Validate build configuration
 
+if [ -z "$CLEAN_SRC_BUILD_DIR" ]; then
+  CLEAN_SRC_BUILD_DIR=No
+elif [ "$CLEAN_SRC_BUILD_DIR" != "Yes" -a "$CLEAN_SRC_BUILD_DIR" != No ]; then
+  echo "Unknown CLEAN_SRC_BUILD_DIR value $CLEAN_SRC_BUILD_DIR: must be one of Yes or No"
+  CHECKEDC_CONFIG_STATUS="error"
+fi
+
 if [ -z "$BUILDCONFIGURATION" ]; then
   echo "BUILDCONFIGURATION not set: must be set to set to one of Debug, Release, ReleaseWithDebInfo"
   CHECKEDC_CONFIG_STATUS="error"  
@@ -183,6 +190,7 @@ if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
   echo " BUILDOS: $BUILDOS"
   echo " TEST_TARGET_ARCH: $TEST_TARGET_ARCH"
   echo " TEST_SUITE: $TEST_SUITE"
+  echo " CLEAN_SRC_BUILD_DIR: $CLEAN_SRC_BUILD_DIR"
   echo " SKIP_CHECKEDC_TESTS: $SKIP_CHECKEDC_TESTS"
   echo " LNT: $LNT"
   echo " LNT_SCRIPT: $LNT_SCRIPT"

--- a/UNIX/test-lit.sh
+++ b/UNIX/test-lit.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# For a description of the config variables set/used here,
-# see automation/Windows/build-and-test.bat.
-
 source ./config-vars.sh
 
 echo "======================================================================"

--- a/UNIX/test-lnt.sh
+++ b/UNIX/test-lnt.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# For a description of the config variables set/used here,
-# see automation/Windows/build-and-test.bat.
-
 source ./config-vars.sh
 
 echo "======================================================================"

--- a/Windows/cleanup.bat
+++ b/Windows/cleanup.bat
@@ -1,0 +1,35 @@
+@echo off
+
+@setlocal
+@call checkedc-automation\Windows\config-vars.bat
+if ERRORLEVEL 1 (goto cmdfailed)
+
+rem Set path to Unix utilities.
+set PATH="C:\GnuWin32\bin";%PATH%
+
+@echo.======================================================================
+@echo.Cleaning Checked C src and build dirs
+@echo.======================================================================
+
+if "%CLEAN_SRC_BUILD_DIR%"=="No" (
+  @echo.Clean.Src.Build.Dir is set to No. Nothing to clean.
+
+) else if "%CLEAN_SRC_BUILD_DIR%"=="Yes" (
+  @echo.Clean.Src.Build.Dir is set to Yes. Trying to clean dirs.
+
+  if exist %BUILD_SOURCESDIRECTORY% (
+    @echo.Cleaning src dir: %BUILD_SOURCESDIRECTORY%
+    rmdir /s /q %BUILD_SOURCESDIRECTORY%
+    if ERRORLEVEL 1 (goto cmdfailed)
+  ) else (
+    @echo.Src dir %BUILD_SOURCESDIRECTORY% not found
+  )
+
+  if exist %LLVM_OBJ_DIR% (
+    @echo.Cleaning build dir: %LLVM_OBJ_DIR%
+    rmdir /s /q %LLVM_OBJ_DIR%
+    if ERRORLEVEL 1 (goto cmdfailed)
+  ) else (
+    @echo.Build dir %LLVM_OBJ_DIR% not found
+  )
+)

--- a/Windows/cleanup.bat
+++ b/Windows/cleanup.bat
@@ -33,3 +33,7 @@ if "%CLEAN_SRC_BUILD_DIR%"=="No" (
     @echo.Build dir %LLVM_OBJ_DIR% not found
   )
 )
+
+:cmdfailed
+  @echo.Cleanup failed
+  exit /b 1

--- a/Windows/config-vars.bat
+++ b/Windows/config-vars.bat
@@ -11,19 +11,15 @@ rem running it manually, the variables must be set by the user.
 
 rem Create configuration variables
 
-if NOT DEFINED BUILD_CHECKEDC_CLEAN (
-  if DEFINED BUILD_CLEAN (
-    set BUILD_CHECKEDC_CLEAN=Yes
-  ) else (
-    set BUILD_CHECKEDC_CLEAN=No
-  )
+if NOT DEFINED CLEAN_SRC_BUILD_DIR (
+  set CLEAN_SRC_BUILD_DIR=No
 ) else (
-  if "%BUILD_CHECKEDC_CLEAN%"=="Yes" (
+  if "%CLEAN_SRC_BUILD_DIR%"=="Yes" (
     rem
-  ) else if "%BUILD_CHECKEDC_CLEAN%"=="No" (
+  ) else if "%CLEAN_SRC_BUILD_DIR%"=="No" (
     rem
   ) else (
-    @echo Unknown BUILD_CHECKEDC_CLEAN value %BUILD_CHECKEDC_CLEAN%: must be one of Yes or No
+    @echo Unknown CLEAN_SRC_BUILD_DIR value %CLEAN_SRC_BUILD_DIR%: must be one of Yes or No
     exit /b /1
   )
 )
@@ -187,7 +183,7 @@ if NOT DEFINED CL_CPU_COUNT (
 @echo.  BUILDOS: %BUILDOS%
 @echo.  TEST_TARGET_ARCH: %TEST_TARGET_ARCH%
 @echo.  TEST_SUITE: %TEST_SUITE%
-@echo.  BUILD_CHECKEDC_CLEAN: %BUILD_CHECKEDC_CLEAN%
+@echo.  CLEAN_SRC_BUILD_DIR: %CLEAN_SRC_BUILD_DIR%
 @echo.  BUILD_PACKAGE: %BUILD_PACKAGE%
 @echo.  SIGN_INSTALLER: %SIGN_INSTALLER%
 @echo.


### PR DESCRIPTION
We added a new ADO option `Clean.Src.Build.Dirs` which is `No` by default. It can
be set to `Yes` by the user from the ADO GUI. Enabling this option will clean the
src and build dirs before invoking an ADO validation.

Fixes https://github.com/microsoft/checkedc-clang/issues/1020