### PR TITLE
Clangd support

### DIFF
--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -69,7 +69,7 @@ elif [[ "$TEST_SUITE" == "CheckedC_LLVM" ]]; then
   ninja -j${BUILD_CPU_COUNT}
 elif [[ "$CLANGD" == "Yes" ]]; then
   echo ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip clangd
-  ninja -j${BUILD_CPU_COUNT}
+  ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip clangd
 else
   echo ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip
   ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip

--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -22,6 +22,12 @@ if [[ ("$LNT" != "" || "$BUILD_PACKAGE" == "Yes") &&
   CMAKE_ADDITIONAL_OPTIONS="-DLLVM_INSTALL_TOOLCHAIN_ONLY=ON -DLLVM_ENABLE_ASSERTIONS=ON"
 fi
 
+if [[ "$CLANGD" == "Yes" ]]; then
+  ENABLEPROJECTS="clang;clang-tools-extra"
+else
+  ENABLEPROJECTS="clang"
+fi
+
 mkdir -p "$LLVM_OBJ_DIR"
 cd "$LLVM_OBJ_DIR"
 
@@ -31,7 +37,7 @@ echo "======================================================================"
 
 echo cmake -G Ninja \
   ${CMAKE_ADDITIONAL_OPTIONS} \
-  -DLLVM_ENABLE_PROJECTS=clang \
+  -DLLVM_ENABLE_PROJECTS="$ENABLEPROJECTS" \
   -DCMAKE_BUILD_TYPE="$BUILDCONFIGURATION" \
   -DCHECKEDC_ARM_RUNUNDER="qemu-arm" \
   -DLLVM_CCACHE_BUILD=ON \
@@ -40,7 +46,7 @@ echo cmake -G Ninja \
 
 cmake -G Ninja \
   ${CMAKE_ADDITIONAL_OPTIONS} \
-  -DLLVM_ENABLE_PROJECTS=clang \
+  -DLLVM_ENABLE_PROJECTS="$ENABLEPROJECTS" \
   -DCMAKE_BUILD_TYPE="$BUILDCONFIGURATION" \
   -DCHECKEDC_ARM_RUNUNDER="qemu-arm" \
   -DLLVM_CCACHE_BUILD=ON \

--- a/UNIX/build.sh
+++ b/UNIX/build.sh
@@ -67,6 +67,9 @@ if [[ "$BUILD_PACKAGE" == "Yes" ]]; then
 elif [[ "$TEST_SUITE" == "CheckedC_LLVM" ]]; then
   echo ninja -j${BUILD_CPU_COUNT}
   ninja -j${BUILD_CPU_COUNT}
+elif [[ "$CLANGD" == "Yes" ]]; then
+  echo ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip clangd
+  ninja -j${BUILD_CPU_COUNT}
 else
   echo ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip
   ninja -j${BUILD_CPU_COUNT} clang llvm-size llvm-strip

--- a/UNIX/config-vars.sh
+++ b/UNIX/config-vars.sh
@@ -173,6 +173,14 @@ else
     export LNT_SCRIPT=/lnt-install/sandbox/bin/lnt
   fi
 fi
+
+# The build of clang-tools-extra is enabled when CLANGD is a non-empty
+# string.
+if [ -z "$CLANGD" ]; then
+  # Make sure CLANGD variable is defined so that scripts that require all variables
+  # to be defined do not break.
+  export CLANGD=""
+fi
  
 if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
   echo "======================================================================"
@@ -185,6 +193,7 @@ if [ "$CHECKEDC_CONFIG_STATUS" == "passed" ]; then
   echo " TEST_SUITE: $TEST_SUITE"
   echo " SKIP_CHECKEDC_TESTS: $SKIP_CHECKEDC_TESTS"
   echo " LNT: $LNT"
+  echo " CLANGD: $CLANGD"
   echo " LNT_SCRIPT: $LNT_SCRIPT"
   echo " RUN_LOCAL: $RUN_LOCAL"
   echo " BENCHMARK: $BMARK"

--- a/UNIX/test-clangd.sh
+++ b/UNIX/test-clangd.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+
+source ./config-vars.sh
+
+echo "======================================================================"
+echo "Running clangd tests using lit for the Checked C compiler"
+echo "======================================================================"
+
+set -ue
+set -o pipefail
+
+export PATH=$LLVM_OBJ_DIR/bin:$PATH
+if [ ! -e "`which clang`" ]; then
+  echo "clang compiler not found"
+  exit 1
+fi
+
+cd $LLVM_OBJ_DIR
+
+echo ninja -v -j${BUILD_CPU_COUNT} check-checkedc
+ninja -v -j${BUILD_CPU_COUNT} check-checkedc
+
+echo ninja -v -j${BUILD_CPU_COUNT} check-clangd
+ninja -v -j${BUILD_CPU_COUNT} check-clangd
+
+set +ue
+set +o pipefail


### PR DESCRIPTION
Support to test the clang daemon `clangd`. An ADO job called "Dev Test Release X64 Linux - clangd" is created to run the clangd tests on demand.